### PR TITLE
feat(#16): add horizontal hour bars between zone rows

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,6 +53,7 @@ function App() {
           homeZone={homeZone}
           onRemove={removeZone}
           onPin={pinTime}
+          onClearPin={clearPin}
           pinnedDate={pinnedDate}
           sourceZone={sourceZone}
           selectedDate={selectedDate}

--- a/src/components/hour-bar.tsx
+++ b/src/components/hour-bar.tsx
@@ -1,36 +1,121 @@
+import { useEffect, useRef, useState, useCallback } from 'react'
 import { getHourInZone } from '@/lib/timezone'
 
 interface HourBarProps {
   timeZone: string
   now: Date
+  onPin: (hours: number, minutes: number, sourceZone: string) => void
+  pinnedDate?: Date | null
+  sourceZone?: string | null
 }
 
 const HOURS = Array.from({ length: 24 }, (_, i) => i)
+const CELL_WIDTH = 40
+const SCROLL_STEP = CELL_WIDTH * 4
 
-export function HourBar({ timeZone, now }: HourBarProps) {
+export function HourBar({ timeZone, now, onPin, pinnedDate }: HourBarProps) {
   const currentHour = getHourInZone(timeZone, now)
+  const pinnedHour = pinnedDate ? getHourInZone(timeZone, pinnedDate) : null
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const [canScrollLeft, setCanScrollLeft] = useState(false)
+  const [canScrollRight, setCanScrollRight] = useState(false)
+
+  const updateArrows = useCallback(() => {
+    const el = scrollRef.current
+    if (!el) return
+    setCanScrollLeft(el.scrollLeft > 0)
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1)
+  }, [])
+
+  // Auto-scroll to center current hour on mount
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    const targetScroll = currentHour * CELL_WIDTH - el.clientWidth / 2 + CELL_WIDTH / 2
+    el.scrollLeft = Math.max(0, targetScroll)
+    updateArrows()
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Update arrows on resize
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    const observer = new ResizeObserver(updateArrows)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [updateArrows])
+
+  const scroll = (direction: 1 | -1) => {
+    const el = scrollRef.current
+    if (!el) return
+    el.scrollBy({ left: direction * SCROLL_STEP, behavior: 'smooth' })
+  }
 
   return (
-    <div className="flex px-6 py-0.5 overflow-x-auto border-b border-border">
-      {HOURS.map((h) => {
-        const isCurrent = h === currentHour
-        const isWorking = h >= 9 && h < 18
+    <div className="relative border-b border-border group/bar">
+      {/* Left arrow */}
+      {canScrollLeft && (
+        <button
+          onClick={() => scroll(-1)}
+          className="absolute left-0 top-0 bottom-0 z-10 w-8 flex items-center justify-center
+            bg-gradient-to-r from-background to-transparent
+            text-muted-foreground hover:text-foreground
+            opacity-0 group-hover/bar:opacity-100 transition-opacity
+            pointer-events-none group-hover/bar:pointer-events-auto"
+          aria-label="Scroll hours left"
+        >
+          ‹
+        </button>
+      )}
 
-        return (
-          <span
-            key={h}
-            className={`flex-1 text-center text-[10px] font-mono leading-4 rounded-sm ${
-              isCurrent
-                ? 'bg-primary text-white font-semibold'
-                : isWorking
-                  ? 'bg-secondary/40 text-muted-foreground'
-                  : 'text-muted-foreground/50'
-            }`}
-          >
-            {h}
-          </span>
-        )
-      })}
+      {/* Hour cells */}
+      <div
+        ref={scrollRef}
+        className="flex px-6 py-0.5 overflow-x-auto scrollbar-hide"
+        onScroll={updateArrows}
+      >
+        {HOURS.map((h) => {
+          const isCurrent = h === currentHour
+          const isPinned = pinnedHour !== null && h === pinnedHour
+          const isWorking = h >= 9 && h < 18
+
+          return (
+            <button
+              key={h}
+              onClick={() => onPin(h, 0, timeZone)}
+              className={`flex-shrink-0 text-center text-xs font-mono rounded-sm
+                min-w-[40px] h-10 flex items-center justify-center
+                transition-colors cursor-pointer
+                ${
+                  isPinned
+                    ? 'bg-primary/20 text-primary ring-1 ring-primary font-semibold'
+                    : isCurrent
+                      ? 'bg-primary text-white font-semibold'
+                      : isWorking
+                        ? 'bg-secondary/40 text-muted-foreground hover:bg-secondary'
+                        : 'text-muted-foreground/50 hover:bg-secondary/30'
+                }`}
+            >
+              {h}
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Right arrow */}
+      {canScrollRight && (
+        <button
+          onClick={() => scroll(1)}
+          className="absolute right-0 top-0 bottom-0 z-10 w-8 flex items-center justify-center
+            bg-gradient-to-l from-background to-transparent
+            text-muted-foreground hover:text-foreground
+            opacity-0 group-hover/bar:opacity-100 transition-opacity
+            pointer-events-none group-hover/bar:pointer-events-auto"
+          aria-label="Scroll hours right"
+        >
+          ›
+        </button>
+      )}
     </div>
   )
 }

--- a/src/components/hour-bar.tsx
+++ b/src/components/hour-bar.tsx
@@ -5,6 +5,7 @@ interface HourBarProps {
   timeZone: string
   now: Date
   onPin: (hours: number, minutes: number, sourceZone: string) => void
+  onClearPin: () => void
   pinnedDate?: Date | null
   sourceZone?: string | null
 }
@@ -13,7 +14,7 @@ const HOURS = Array.from({ length: 24 }, (_, i) => i)
 const CELL_WIDTH = 40
 const SCROLL_STEP = CELL_WIDTH * 4
 
-export function HourBar({ timeZone, now, onPin, pinnedDate }: HourBarProps) {
+export function HourBar({ timeZone, now, onPin, onClearPin, pinnedDate }: HourBarProps) {
   const currentHour = getHourInZone(timeZone, now)
   const pinnedHour = pinnedDate ? getHourInZone(timeZone, pinnedDate) : null
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -82,7 +83,7 @@ export function HourBar({ timeZone, now, onPin, pinnedDate }: HourBarProps) {
           return (
             <button
               key={h}
-              onClick={() => onPin(h, 0, timeZone)}
+              onClick={() => isPinned ? onClearPin() : onPin(h, 0, timeZone)}
               className={`flex-shrink-0 text-center text-xs font-mono rounded-sm
                 min-w-[40px] h-10 flex items-center justify-center
                 transition-colors cursor-pointer

--- a/src/components/hour-bar.tsx
+++ b/src/components/hour-bar.tsx
@@ -1,0 +1,36 @@
+import { getHourInZone } from '@/lib/timezone'
+
+interface HourBarProps {
+  timeZone: string
+  now: Date
+}
+
+const HOURS = Array.from({ length: 24 }, (_, i) => i)
+
+export function HourBar({ timeZone, now }: HourBarProps) {
+  const currentHour = getHourInZone(timeZone, now)
+
+  return (
+    <div className="flex px-6 py-0.5 overflow-x-auto border-b border-border">
+      {HOURS.map((h) => {
+        const isCurrent = h === currentHour
+        const isWorking = h >= 9 && h < 18
+
+        return (
+          <span
+            key={h}
+            className={`flex-1 text-center text-[10px] font-mono leading-4 rounded-sm ${
+              isCurrent
+                ? 'bg-primary text-white font-semibold'
+                : isWorking
+                  ? 'bg-secondary/40 text-muted-foreground'
+                  : 'text-muted-foreground/50'
+            }`}
+          >
+            {h}
+          </span>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/zone-list.tsx
+++ b/src/components/zone-list.tsx
@@ -8,6 +8,7 @@ interface ZoneListProps {
   homeZone: string
   onRemove: (tz: string) => void
   onPin: (hours: number, minutes: number, sourceZone: string) => void
+  onClearPin: () => void
   pinnedDate?: Date | null
   sourceZone?: string | null
   selectedDate?: Date
@@ -19,6 +20,7 @@ export function ZoneList({
   homeZone,
   onRemove,
   onPin,
+  onClearPin,
   pinnedDate,
   sourceZone,
   selectedDate,
@@ -52,6 +54,7 @@ export function ZoneList({
               timeZone={tz}
               now={now}
               onPin={onPin}
+              onClearPin={onClearPin}
               pinnedDate={pinnedDate}
               sourceZone={sourceZone}
             />

--- a/src/components/zone-list.tsx
+++ b/src/components/zone-list.tsx
@@ -48,7 +48,13 @@ export function ZoneList({
               selectedDate={selectedDate}
               onDateSelect={onDateSelect}
             />
-            <HourBar timeZone={tz} now={now} />
+            <HourBar
+              timeZone={tz}
+              now={now}
+              onPin={onPin}
+              pinnedDate={pinnedDate}
+              sourceZone={sourceZone}
+            />
           </div>
         ))}
       </div>

--- a/src/components/zone-list.tsx
+++ b/src/components/zone-list.tsx
@@ -1,4 +1,5 @@
 import { ZoneRow } from './zone-row'
+import { HourBar } from './hour-bar'
 import { useClock } from '@/hooks/use-clock'
 import { canAddZone } from '@/lib/timezone'
 
@@ -35,18 +36,20 @@ export function ZoneList({
       </div>
       <div className="border-t border-border" data-testid="zone-list">
         {zones.map((tz) => (
-          <ZoneRow
-            key={tz}
-            timeZone={tz}
-            isHome={tz === homeZone}
-            now={now}
-            onRemove={onRemove}
-            onPin={onPin}
-            pinnedDate={pinnedDate}
-            sourceZone={sourceZone}
-            selectedDate={selectedDate}
-            onDateSelect={onDateSelect}
-          />
+          <div key={tz}>
+            <ZoneRow
+              timeZone={tz}
+              isHome={tz === homeZone}
+              now={now}
+              onRemove={onRemove}
+              onPin={onPin}
+              pinnedDate={pinnedDate}
+              sourceZone={sourceZone}
+              selectedDate={selectedDate}
+              onDateSelect={onDateSelect}
+            />
+            <HourBar timeZone={tz} now={now} />
+          </div>
         ))}
       </div>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -101,3 +101,11 @@
     @apply font-sans antialiased;
   }
 }
+
+.scrollbar-hide {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- New `HourBar` component: compact 0–23 hour strip rendered below each zone row
- Each bar shows hours in the zone's local time
- Current hour highlighted with accent color (`#5b5ef4`)
- Working hours (9–17) have subtle background tint

Closes #16

## Test plan
- [x] `pnpm build` passes (typecheck + build)
- [x] `pnpm test` passes (52/52 tests)
- [ ] Visual check: hour bars appear below each zone, current hour highlighted, working hours tinted
- [ ] Responsive: bars don't overflow on smaller screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)