### PR TITLE
feat(#18): add haptic feedback to core UI interactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "shadcn": "^4.1.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "web-haptics": "^0.0.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      web-haptics:
+        specifier: ^0.0.6
+        version: 0.0.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.4
@@ -3869,6 +3872,23 @@ packages:
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
+
+  web-haptics@0.0.6:
+    resolution: {integrity: sha512-eCzcf1LDi20+Fr0x9V3OkX92k0gxEQXaHajmhXHitsnk6SxPeshv8TBtBRqxyst8HI1uf2FyFVE7QS3jo1gkrw==}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+      svelte: '>=4'
+      vue: '>=3'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -7938,6 +7958,11 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
+
+  web-haptics@0.0.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   web-streams-polyfill@3.3.3: {}
 

--- a/src/components/date-nav.tsx
+++ b/src/components/date-nav.tsx
@@ -1,4 +1,5 @@
 import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { useWebHaptics } from 'web-haptics/react'
 import { Button } from '@/components/ui/button'
 import { Calendar } from '@/components/ui/calendar'
 import {
@@ -25,12 +26,13 @@ export function DateNav({
   onToday,
   onDateSelect,
 }: DateNavProps) {
+  const { trigger } = useWebHaptics()
   return (
     <div className="flex items-center gap-2" data-testid="date-nav">
       <Button
         variant="ghost"
         size="icon"
-        onClick={onPrevDay}
+        onClick={() => { trigger('nudge'); onPrevDay() }}
         aria-label="Previous day"
         data-testid="prev-day"
         className="h-8 w-8"
@@ -59,7 +61,7 @@ export function DateNav({
       <Button
         variant="ghost"
         size="icon"
-        onClick={onNextDay}
+        onClick={() => { trigger('nudge'); onNextDay() }}
         aria-label="Next day"
         data-testid="next-day"
         className="h-8 w-8"
@@ -71,7 +73,7 @@ export function DateNav({
         <Button
           variant="outline"
           size="sm"
-          onClick={onToday}
+          onClick={() => { trigger('success'); onToday() }}
           data-testid="back-to-today"
           className="ml-2 text-xs h-7"
         >

--- a/src/components/hour-bar.tsx
+++ b/src/components/hour-bar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
+import { useWebHaptics } from 'web-haptics/react'
 import { getHourInZone } from '@/lib/timezone'
 
 interface HourBarProps {
@@ -15,6 +16,7 @@ const CELL_WIDTH = 40
 const SCROLL_STEP = CELL_WIDTH * 4
 
 export function HourBar({ timeZone, now, onPin, onClearPin, pinnedDate }: HourBarProps) {
+  const { trigger } = useWebHaptics()
   const currentHour = getHourInZone(timeZone, now)
   const pinnedHour = pinnedDate ? getHourInZone(timeZone, pinnedDate) : null
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -83,7 +85,7 @@ export function HourBar({ timeZone, now, onPin, onClearPin, pinnedDate }: HourBa
           return (
             <button
               key={h}
-              onClick={() => isPinned ? onClearPin() : onPin(h, 0, timeZone)}
+              onClick={() => { trigger(isPinned ? 'nudge' : 'success'); isPinned ? onClearPin() : onPin(h, 0, timeZone) }}
               className={`flex-shrink-0 text-center text-xs font-mono rounded-sm
                 min-w-[40px] h-10 flex items-center justify-center
                 transition-colors cursor-pointer

--- a/src/components/overlap-panel.tsx
+++ b/src/components/overlap-panel.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from 'react'
+import { useWebHaptics } from 'web-haptics/react'
 import { getCityName } from '@/lib/timezone'
 import {
   calculateOverlap,
@@ -14,6 +15,7 @@ interface OverlapPanelProps {
 }
 
 export function OverlapPanel({ zones, homeZone, date }: OverlapPanelProps) {
+  const { trigger } = useWebHaptics()
   const [selectedZones, setSelectedZones] = useState<Set<string>>(
     () => new Set(zones),
   )
@@ -61,7 +63,7 @@ export function OverlapPanel({ zones, homeZone, date }: OverlapPanelProps) {
               <input
                 type="checkbox"
                 checked={activeSelected.has(tz)}
-                onChange={() => toggleZone(tz)}
+                onChange={() => { trigger('nudge'); toggleZone(tz) }}
                 className="accent-primary"
                 data-testid={`checkbox-${tz}`}
               />

--- a/src/components/time-picker-popover.tsx
+++ b/src/components/time-picker-popover.tsx
@@ -1,4 +1,5 @@
 import { useRef, useCallback, useEffect, useState } from 'react'
+import { useWebHaptics } from 'web-haptics/react'
 import { Pin } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import {
@@ -105,6 +106,7 @@ export function TimePickerPopover({
   isPinned,
   onPin,
 }: TimePickerPopoverProps) {
+  const { trigger } = useWebHaptics()
   const [open, setOpen] = useState(false)
   const [hour, setHour] = useState(() => getHourInZone(timeZone))
   const [minute, setMinute] = useState(() => getMinuteInZone(timeZone))
@@ -121,17 +123,19 @@ export function TimePickerPopover({
   const handleHourChange = useCallback(
     (h: number) => {
       setHour(h)
+      trigger(20)
       onPin(h, minute, timeZone)
     },
-    [minute, timeZone, onPin],
+    [minute, timeZone, onPin, trigger],
   )
 
   const handleMinuteChange = useCallback(
     (m: number) => {
       setMinute(m)
+      trigger(10)
       onPin(hour, m, timeZone)
     },
-    [hour, timeZone, onPin],
+    [hour, timeZone, onPin, trigger],
   )
 
   return (

--- a/src/components/zone-row.tsx
+++ b/src/components/zone-row.tsx
@@ -1,4 +1,5 @@
 import { X } from 'lucide-react'
+import { useWebHaptics } from 'web-haptics/react'
 import { cn } from '@/lib/utils'
 import { Calendar } from '@/components/ui/calendar'
 import {
@@ -49,6 +50,7 @@ export function ZoneRow({
   selectedDate,
   onDateSelect,
 }: ZoneRowProps) {
+  const { trigger } = useWebHaptics()
   const displayDate = pinnedDate ?? now
   const status = getZoneStatus(timeZone, displayDate)
   const dayOffset = pinnedDate && sourceZone
@@ -117,7 +119,7 @@ export function ZoneRow({
           </span>
         </div>
         <button
-          onClick={() => onRemove(timeZone)}
+          onClick={() => { trigger('error'); onRemove(timeZone) }}
           className="p-0.5 rounded text-muted-foreground/40 hover:text-foreground hover:bg-secondary transition-colors"
           aria-label={`Remove ${getCityName(timeZone)}`}
           data-testid="remove-zone"


### PR DESCRIPTION
Integrate web-haptics library across 5 interactive touch points:
- Hour bar cell tap (pin/unpin): success/nudge haptics
- Date nav buttons (prev/next/today): nudge/success haptics
- Time picker scroll wheel: short pulse on snap
- Remove zone button: error haptic pattern
- Overlap panel checkboxes: nudge on toggle

Closes #18